### PR TITLE
Opt-out of branch protection for private repos and opt-in security policies

### DIFF
--- a/allstar.yaml
+++ b/allstar.yaml
@@ -1,2 +1,3 @@
 optConfig:
+  disableRepoOverride: true
   optOutStrategy: true

--- a/branch_protection.yaml
+++ b/branch_protection.yaml
@@ -1,3 +1,4 @@
 optConfig:
   optOutStrategy: true
+  optOutPrivateRepos: true
 action: issue

--- a/security.yaml
+++ b/security.yaml
@@ -1,3 +1,3 @@
 optConfig:
-  optOutStrategy: true
+  optOutStrategy: false
 action: issue


### PR DESCRIPTION
- Disable repository overrides
- Opt-out of branch protection for private repos
  ...as it's not possible to protect private repo branches without
  GitHub Pro.
- Set SECURITY.md policy to opt-in (temporarily)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

ref: https://github.com/inclusivenaming/ini-infra/issues/13